### PR TITLE
Authentication Controller Functionality

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,7 +6,7 @@ import { Container, Box } from '@mui/material';
 import { Provider } from 'react-redux';
 import { theme } from 'src/theme';
 import { useStore } from 'src/hooks';
-import { Navbar, Notification } from 'src/modules';
+import { Navbar, Notification, AuthenticationController } from 'src/modules';
 
 export default function App({ Component, pageProps }: AppProps) {
   const store = useStore(pageProps.initialReduxState);
@@ -18,9 +18,10 @@ export default function App({ Component, pageProps }: AppProps) {
         <Box width="100vw" position="relative">
           <Container maxWidth="xl" disableGutters>
             <Notification />
-            {/* TODO: Wrap <Component> within some sort of <Auth> component when authRequired is true */}
             {pageProps.authRequired ? (
-              <Component {...pageProps} />
+              <AuthenticationController>
+                <Component {...pageProps} />
+              </AuthenticationController>
             ) : (
               <Component {...pageProps} />
             )}

--- a/src/modules/AuthenticationController/AuthenticationController.tsx
+++ b/src/modules/AuthenticationController/AuthenticationController.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { BackdropLayout } from './layout';
+import { useIsAuthenticated } from './hooks';
+import { useRouter } from 'next/router';
+import { ROUTES } from 'src/constants';
+import { useDispatchShowNotification } from 'src/hooks';
+
+interface AuthenticationControllerProps {
+  children: React.ReactNode;
+}
+
+const AuthenticationController = ({ children }: AuthenticationControllerProps) => {
+  const isAuthenticated = useIsAuthenticated();
+  const router = useRouter();
+  const showNotification = useDispatchShowNotification();
+
+  React.useEffect(() => {
+    if (!isAuthenticated) {
+      router
+        .push({
+          pathname: ROUTES.SIGN_IN,
+          query: { ...router.query, returnRoute: router.pathname },
+        })
+        .then(() => {
+          showNotification('you must be logged in to access JSOM CMS', 'info');
+        });
+    }
+  }, [isAuthenticated, router, showNotification]);
+
+  return !isAuthenticated ? <BackdropLayout /> : <>{children}</>;
+};
+
+export default AuthenticationController;

--- a/src/modules/AuthenticationController/components/Backdrop/Backdrop.tsx
+++ b/src/modules/AuthenticationController/components/Backdrop/Backdrop.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Backdrop as MUIBackdrop, BackdropProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const StyledBackdrop = styled(MUIBackdrop)(({ theme }) => ({
+  zIndex: theme.zIndex.drawer + 1,
+  color: theme.palette.common.white,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+}));
+
+const Backdrop = ({ children, ...backdropProps }: BackdropProps) => {
+  return <StyledBackdrop {...backdropProps}>{children}</StyledBackdrop>;
+};
+
+export default Backdrop;

--- a/src/modules/AuthenticationController/components/Backdrop/index.ts
+++ b/src/modules/AuthenticationController/components/Backdrop/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Backdrop';

--- a/src/modules/AuthenticationController/components/index.ts
+++ b/src/modules/AuthenticationController/components/index.ts
@@ -1,0 +1,1 @@
+export { default as Backdrop } from './Backdrop';

--- a/src/modules/AuthenticationController/hooks/index.ts
+++ b/src/modules/AuthenticationController/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useIsAuthenticated } from './useIsAuthenticated';

--- a/src/modules/AuthenticationController/hooks/useIsAuthenticated/index.ts
+++ b/src/modules/AuthenticationController/hooks/useIsAuthenticated/index.ts
@@ -1,0 +1,1 @@
+export { default } from './useIsAuthenticated';

--- a/src/modules/AuthenticationController/hooks/useIsAuthenticated/useIsAuthenticated.ts
+++ b/src/modules/AuthenticationController/hooks/useIsAuthenticated/useIsAuthenticated.ts
@@ -1,0 +1,10 @@
+import { useSelector } from 'react-redux';
+import { RootState } from 'src/store/store';
+
+function useIsAuthenticated() {
+  const token = useSelector(({ auth }: RootState) => auth.token);
+  const isAuthenticated = !!token;
+  return isAuthenticated;
+}
+
+export default useIsAuthenticated;

--- a/src/modules/AuthenticationController/index.ts
+++ b/src/modules/AuthenticationController/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AuthenticationController';

--- a/src/modules/AuthenticationController/layout/BackdropLayout.tsx
+++ b/src/modules/AuthenticationController/layout/BackdropLayout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Backdrop } from 'src/modules/AuthenticationController/components';
+import { Typography, CircularProgress, Box } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+
+const BackdropLayout = () => {
+  const theme = useTheme();
+  return (
+    <Backdrop open={true}>
+      <Box marginBottom={theme.spacing(3)}>
+        <CircularProgress color="inherit" />
+      </Box>
+      <Typography variant="h5">Checking Authentication Status...</Typography>
+    </Backdrop>
+  );
+};
+
+export default BackdropLayout;

--- a/src/modules/AuthenticationController/layout/index.ts
+++ b/src/modules/AuthenticationController/layout/index.ts
@@ -1,0 +1,1 @@
+export { default as BackdropLayout } from './BackdropLayout';

--- a/src/modules/Notification/Notification.tsx
+++ b/src/modules/Notification/Notification.tsx
@@ -11,15 +11,13 @@ const Notification = () => {
   const { message, notificationType, showNotification } = useNotification();
   const hideNotification = useDispatchHideNotification();
   const router = useRouter();
-  const currentRoute = React.useRef<string>(router.pathname);
 
-  // Close open nofitifcations on route change.
   React.useEffect(() => {
-    if (currentRoute.current && router.pathname !== currentRoute.current) {
-      hideNotification();
-      currentRoute.current = router.pathname;
-    }
-  }, [hideNotification, router]);
+    router.events.on('routeChangeStart', hideNotification);
+    return () => {
+      router.events.off('routeChangeStart', hideNotification);
+    };
+  }, [router, hideNotification]);
 
   const handleClose = React.useCallback(() => {
     hideNotification();

--- a/src/modules/Notification/components/CloseButton/CloseButton.tsx
+++ b/src/modules/Notification/components/CloseButton/CloseButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { IconButton } from '@mui/material';
-import { styled } from '@mui/material/styles';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faClose } from '@fortawesome/free-solid-svg-icons';
 
@@ -8,15 +7,11 @@ interface CloseButtonProps {
   onClick: () => void;
 }
 
-const StyledIconButton = styled(IconButton)(() => ({
-  color: 'inherit',
-}));
-
 const CloseButton = ({ onClick }: CloseButtonProps) => {
   return (
-    <StyledIconButton disableTouchRipple onClick={onClick}>
+    <IconButton disableTouchRipple onClick={onClick} color="inherit">
       <FontAwesomeIcon icon={faClose} size="sm" fixedWidth />
-    </StyledIconButton>
+    </IconButton>
   );
 };
 

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -2,3 +2,4 @@ export { default as Navbar } from './Navbar';
 export { default as LoginForm } from './LoginForm';
 export { default as SignUpForm } from './SignUpForm';
 export { default as Notification } from './Notification';
+export { default as AuthenticationController } from './AuthenticationController';


### PR DESCRIPTION
I need a way to ensure that users are logged in when they hit certain pages in the app. Using the Next's SSR rendering method we can set a `pageProp` to flag when want to require authentication and with our custom `_app` we can wrap those pages in an additional React component that is named `AuthenticationController`.

This component's job is to keep track of the auth token that we have in the store and if we see it is missing it will render a Backdrop + Text while the application redirects you to the login page.

This PR contains:
* Added `AuthenticationController` to enforce authentication on specific pages.
* Updated `Notification` useEffect that hides notifications on route change.